### PR TITLE
GLFW: Include missing header

### DIFF
--- a/Examples/Common/Application/Source/GLFW/Entry.cpp
+++ b/Examples/Common/Application/Source/GLFW/Entry.cpp
@@ -11,6 +11,7 @@
 #include "Application.h"
 #include <vector>
 #include <algorithm>
+#include <cstdint>
 
 #define STB_IMAGE_IMPLEMENTATION
 extern "C" {


### PR DESCRIPTION
It seems the header `<cstdint>` was missing, causing the code to fail to
compile on my system (Ubuntu 17.10 with g++ 7.2.0).

The error below occurred during compilation:

```
imgui-node-editor/Examples/Common/Application/Source/GLFW/Entry.cpp:70:64:
error: ‘intptr_t’ in namespace ‘std’ does not name a type
```

This commit fixes the above error. I can run the examples without issue after the fix.


I hope someone can check it does not break anything on other platforms!