### PR TITLE
crude_json: Fix to accept number exactly zero

### DIFF
--- a/NodeEditor/Source/crude_json.cpp
+++ b/NodeEditor/Source/crude_json.cpp
@@ -575,7 +575,7 @@ private:
             if (end != n.c_str() + n.size())
                 return false;
 
-            if (!std::isnormal(v))
+            if (v != 0 && !std::isnormal(v))
                 return false;
 
             result = v;


### PR DESCRIPTION
json::value::parse fails if json string includes number "0".
std::isnormal(v) returns false if v == 0.