### PR TITLE
Added StyleVar_Count to StyleVar enum for easier iteration

### DIFF
--- a/imgui_node_editor.h
+++ b/imgui_node_editor.h
@@ -134,6 +134,8 @@ enum StyleVar
     StyleVar_PinArrowWidth,
     StyleVar_GroupRounding,
     StyleVar_GroupBorderWidth,
+
+    StyleVar_Count
 };
 
 struct Style


### PR DESCRIPTION
I found myself in need to know the amount of possible values of the StyleVar enum, but unlike the StyleColor enum it does not have a _Count value. Maybe other people can also use this change :)

PS. thanks for your time and your great library