### PR TITLE
Make it possible to use canvas in floating ImGuiWindow

### DIFF
--- a/imgui_canvas.cpp
+++ b/imgui_canvas.cpp
@@ -128,6 +128,7 @@ bool ImGuiEx::Canvas::Begin(ImGuiID id, const ImVec2& size)
     ImGui::Dummy(m_ViewRect.GetSize());
 
     ImGui::SetCursorScreenPos(ImVec2(0.0f, 0.0f));
+	ImGui::BeginGroup();
 
     m_InBeginEnd = true;
 
@@ -149,6 +150,8 @@ void ImGuiEx::Canvas::End()
 
     // Check: Unmatched calls to Suspend() / Resume(). Please check your code.
     IM_ASSERT(m_SuspendCounter == 0);
+
+	ImGui::EndGroup();
 
     LeaveLocalSpace();
 


### PR DESCRIPTION
Because there was no `ImGui::BeginGroup()`,  
 the only first item was correctly aligned, but others move when floating window move around.    
  
Fixed it and it works great with floating window  
  
Before :   
![before](https://user-images.githubusercontent.com/16120321/97162747-f9faf580-17c2-11eb-8952-5df84f13615f.gif)  
  
After : 
![after](https://user-images.githubusercontent.com/16120321/97162817-1139e300-17c3-11eb-9238-69cfec9cc048.gif)

