### PR TITLE
Cmake GLEW linking

### DIFF
--- a/examples/application/CMakeLists.txt
+++ b/examples/application/CMakeLists.txt
@@ -55,6 +55,7 @@ if (WIN32)
 else()
     find_package(OpenGL REQUIRED)
     find_package(glfw3 3 REQUIRED)
+    find_package(GLEW REQUIRED)
 
     if (APPLE)
         target_link_libraries(application PRIVATE
@@ -87,6 +88,12 @@ if (glfw3_FOUND)
     )
     target_link_libraries(application PRIVATE
         glfw
+    )
+endif()
+
+if (GLEW_FOUND)
+    target_link_libraries(application PRIVATE
+        GLEW
     )
 endif()
 


### PR DESCRIPTION
Hello,

your current develop branch was not linking correctly under Arch Linux.

I got errors like this
```
/usr/bin/ld: ../application/libapplication.a(imgui_impl_opengl3.cpp.o): warning: relocation against `__glewGetUniformLocation' in read-only section `.text'
/usr/bin/ld: ../application/libapplication.a(renderer_ogl3.cpp.o): in function `RendererOpenGL3::Create(Platform&)':
renderer_ogl3.cpp:(.text+0x7f): undefined reference to `glewInit'
/usr/bin/ld: ../application/libapplication.a(imgui_impl_opengl3.cpp.o): in function `ImGui_ImplOpenGL3_SetupRenderState(ImDrawData*, int, int, unsigned int)':
imgui_impl_opengl3.cpp:(.text+0x1a0): undefined reference to `__glewBlendEquation'
/usr/bin/ld: imgui_impl_opengl3.cpp:(.text+0x378): undefined reference to `__glewUseProgram'
/usr/bin/ld: imgui_impl_opengl3.cpp:(.text+0x389): undefined reference to `__glewUniform1i'
...
```
To fix this, I had to link glew to the application library.