### PR TITLE
Advanced link path layout when it intersects source or target node

### DIFF
--- a/imgui_node_editor.cpp
+++ b/imgui_node_editor.cpp
@@ -976,9 +976,9 @@ ed::LinkPath ed::Link::GetCurve() const
 
     const float rounding = 5.0f;
     const float margin = 10.0f;
-    const float xsepf = 5.0f;
-    const float ysepf = 5.0f;
-    const float xsep = float(startPinIndex) * xsepf;
+    const float xsepf = 7.0f;
+    const float ysepf = 7.0f;
+    const float xsep = float(startPinIndex) * xsepf + 2.0f;
     const float ysep = float(startPinIndex) * ysepf - (float(startNodeOutPinCount - 1)) * ysepf / 2.0f;
 
     if(pathType == ed::LinkPathType_Under_Over)

--- a/imgui_node_editor.cpp
+++ b/imgui_node_editor.cpp
@@ -927,7 +927,7 @@ ed::LinkPathType ed::Link::GetPathType(ImRect& fromRect, ImRect& toRect) const
         toRect.Max = toRect.Min + ImVec2(1, 1);
     }
 
-    if(toRect.Min.x > fromRect.Max.x)
+    if(m_End.x > fromRect.Max.x)
     {
         return ed::LinkPathType_Default;
     }

--- a/imgui_node_editor.cpp
+++ b/imgui_node_editor.cpp
@@ -878,7 +878,8 @@ void ed::Link::Draw(ImDrawList* drawList, ImU32 color, float extraThickness) con
         ImDrawList_AddBezierWithArrows(drawList, bezier, m_Thickness + extraThickness, startArrowSize,
                                        startArrowWidth, endArrowSize, endArrowWidth, true, color, 1.0f);
 
-        if(!isEnd) {
+        if(!isEnd)
+        {
             const auto bezier1 = ImCubicBezierPoints { curve.m_Points[i + 3], curve.m_Points[i + 3],
                                                        curve.m_Points[i + 4], curve.m_Points[i + 4] };
             ImDrawList_AddBezierWithArrows(drawList, bezier1, m_Thickness + extraThickness,
@@ -909,17 +910,11 @@ ed::LinkPathType ed::Link::GetPathType(ImRect& fromRect, ImRect& toRect) const
     toRect = m_EndPin->m_Node->m_Bounds;
 
     if(m_End.x > fromRect.Max.x)
-    {
         return ed::LinkPathType_Default;
-    }
     else if(toRect.Min.y > fromRect.Max.y)
-    {
         return ed::LinkPathType_Under_Over;
-    }
     else if(toRect.Max.y < fromRect.Min.y)
-    {
         return ed::LinkPathType_Over_Under;
-    }
 
     return ed::LinkPathType_Under_Under;
 }
@@ -936,7 +931,7 @@ ed::LinkPath ed::Link::GetCurve() const
     if(pathType == ed::LinkPathType_Default)
     {
         auto easeLinkStrength = [](const ImVec2& a, const ImVec2& b, float strength)
-                {
+        {
             const auto distanceX    = b.x - a.x;
             const auto distanceY    = b.y - a.y;
             const auto distance     = ImSqrt(distanceX * distanceX + distanceY * distanceY);
@@ -946,7 +941,7 @@ ed::LinkPath ed::Link::GetCurve() const
                 strength = strength * ImSin(IM_PI * 0.5f * halfDistance / strength);
 
             return strength;
-                };
+        };
 
         const auto startStrength = easeLinkStrength(m_Start, m_End, m_StartPin->m_Strength);
         const auto   endStrength = easeLinkStrength(m_Start, m_End,   m_EndPin->m_Strength);

--- a/imgui_node_editor.cpp
+++ b/imgui_node_editor.cpp
@@ -896,36 +896,17 @@ void ed::Link::UpdateEndpoints()
 
 ed::LinkPathType ed::Link::GetPathType(ImRect& fromRect, ImRect& toRect) const
 {
-    if(m_StartPin && m_StartPin->m_Dir != ImVec2(1.0f, 0.0f))
-    {
-        // disable advanced path layout for pins which do not output to the right
-        return LinkPathType_Default;
-    }
+    const bool isDefault = m_StartPin && m_StartPin->m_Dir != ImVec2(1.0f, 0.0f)
+            || m_EndPin && m_EndPin->m_Dir != ImVec2(-1.0f, 0.0f)
+            || !m_EndPin || !m_EndPin->m_Node
+            || !m_StartPin || !m_StartPin->m_Node;
 
-    if(m_EndPin && m_EndPin->m_Dir != ImVec2(-1.0f, 0.0f))
-    {
-        // disable advanced path layout for pins which do not take input from the left
+    if(isDefault)
         return LinkPathType_Default;
-    }
 
-    if(m_StartPin && m_StartPin->m_Node)
-    {
-        fromRect = m_StartPin->m_Node->m_Bounds;
-    }
-    else
-    {
-        fromRect.Min = m_Start;
-        fromRect.Max = fromRect.Min + ImVec2(1, 1);
-    }
-    if(m_EndPin && m_EndPin->m_Node)
-    {
-        toRect = m_EndPin->m_Node->m_Bounds;
-    }
-    else
-    {
-        toRect.Min = m_End;
-        toRect.Max = toRect.Min + ImVec2(1, 1);
-    }
+
+    fromRect = m_StartPin->m_Node->m_Bounds;
+    toRect = m_EndPin->m_Node->m_Bounds;
 
     if(m_End.x > fromRect.Max.x)
     {

--- a/imgui_node_editor_internal.h
+++ b/imgui_node_editor_internal.h
@@ -432,6 +432,19 @@ struct Node final: Object
     virtual Node* AsNode() override final { return this; }
 };
 
+enum LinkPathType {
+    LinkPathType_Default,
+    LinkPathType_Under_Over,
+    LinkPathType_Over_Under,
+    LinkPathType_Under_Under
+};
+
+struct LinkPath {
+    ImVec2 m_Points[16];
+    int m_NumPoint;
+    LinkPathType m_Type;
+};
+
 struct Link final: Object
 {
     using IdType = LinkId;
@@ -463,7 +476,8 @@ struct Link final: Object
 
     void UpdateEndpoints();
 
-    ImCubicBezierPoints GetCurve() const;
+    LinkPathType GetPathType(ImRect& fromRect, ImRect& toRect) const;
+    LinkPath GetCurve() const;
 
     virtual bool TestHit(const ImVec2& point, float extraThickness = 0.0f) const override final;
     virtual bool TestHit(const ImRect& rect, bool allowIntersect = true) const override final;


### PR DESCRIPTION
Hi!

This pull request implements improved behaviour for links drawing in cases when drawing it using simple bezier curve would intersect either target or source node. This idea is mainly inspired by implementation of creation graphs in The Machinery engine ([reference image](https://i.imgur.com/Z9Efzsf.png), notice behaviour of links between nodes at the very bottom).

In many cases this makes it much easier to keep readiblity while maintaining complex graphs and it's quite a noticeable UX improvement in comparison, with, e.g. UE4's Blueprints.

Demonstration of links difference with, and without this feature:
![demo_1_1](https://user-images.githubusercontent.com/8457835/130707264-fa319050-f33d-477c-97bb-57f47e9e540b.png)
![demo_1_2](https://user-images.githubusercontent.com/8457835/130707265-178fbb28-f1fb-4659-ac5f-fc770e9a745a.png)

Demonstation of link behaviour when node is moved:
![demo_node_editor](https://user-images.githubusercontent.com/8457835/130708559-fa83df4f-62e9-4e17-bdd0-e01c264d8a73.gif)


Right now proposed implementation is more like a prototype and not really finalized, I am willing to work on it further if you think that this is appropriate addition for imgui-node-editor. 

During implementation I tried to keep code simple and reuse existing functionality as much as possible. The most noticable change is in the way link's curve is represented, instead of four bezier points it's now a struct which contains up to 16 points (`NodeEditor::Detail::LinkPath`). New types of links will be used only when start pin outputs to the right (with dir 1, 0) and end pin takes input from the left (with dir -1, 0)

If link can be drawn with a simple bezier then only first 4 points will be used and filled with control points for a single curve (just as before). If  `Link::GetPathType` decides that link can intersect source or target node then curve will be constructed from four bezier curves, each describing one corner of the path. During link processing routines (rendering, hit testing, etc) for such cases additional straight line will be derived from each 4nth and 5th point (except for the last pair). These derived straight lines are still interpreted as beziers in order to reuse existing code.

Current known issues/further improvements:
- I am a little unsure whether this feature should be enabled by default, since in some cases it might be not appropriate. I think we can add style option which controls this behaviour and set it disabled initially.
- Current implementation of complex curve rendering can produce a bit of a gap between corner beziers and straight lines pieces. I am struggling with fixing it but luckily this gap is not really noticeable unless you zoom really close
- There are some hidden constants in new path layouting code, which can be exposed via style interface.

