### PR TITLE
Add missing header

### DIFF
--- a/examples/application/source/renderer_ogl3.cpp
+++ b/examples/application/source/renderer_ogl3.cpp
@@ -4,6 +4,7 @@
 
 # include "platform.h"
 # include <algorithm>
+# include <cstdint>
 
 # if PLATFORM(WINDOWS)
 #     define NOMINMAX


### PR DESCRIPTION
This resolves the error

```
examples/application/source/renderer_ogl3.cpp:165:59: error: ‘intptr_t’ in namespace ‘std’ does not name a type
```