### PR TITLE
Fix for compatibility with latest imgui version (arg count for ImGui::isClippedEx())

### DIFF
--- a/imgui_canvas.cpp
+++ b/imgui_canvas.cpp
@@ -1,4 +1,4 @@
-﻿# define IMGUI_DEFINE_MATH_OPERATORS
+# define IMGUI_DEFINE_MATH_OPERATORS
 # include "imgui_canvas.h"
 # include <type_traits>
 
@@ -101,7 +101,7 @@ bool ImGuiEx::Canvas::Begin(ImGuiID id, const ImVec2& size)
 
     UpdateViewTransformPosition();
 
-    if (ImGui::IsClippedEx(m_WidgetRect, id, false))
+    if (ImGui::IsClippedEx(m_WidgetRect, id))
         return false;
 
     // Save current channel, so we can assert when user


### PR DESCRIPTION
This ImGui commit removed the third argument for the function:
3973de793316e84bee8719bf29091df1ad61b514
I just removed it to build with the latest imgui version.