### PR TITLE
Blueprints example: Fix drawing of header-content line

### DIFF
--- a/examples/blueprints-example/utilities/builders.cpp
+++ b/examples/blueprints-example/utilities/builders.cpp
@@ -72,15 +72,11 @@ void util::BlueprintNodeBuilder::End()
                 headerColor, GetStyle().NodeRounding, 1 | 2);
 #endif
 
-
-            auto headerSeparatorMin = ImVec2(HeaderMin.x, HeaderMax.y);
-            auto headerSeparatorMax = ImVec2(ContentMax.x, ContentMin.y);
-
-            if ((headerSeparatorMax.x > headerSeparatorMin.x) && (headerSeparatorMax.y > headerSeparatorMin.y))
+            if (ContentMin.y > HeaderMax.y)
             {
                 drawList->AddLine(
-                    ImVec2(headerSeparatorMin.x - (8 - halfBorderWidth), headerSeparatorMin.y  -0.5f),
-                    ImVec2(headerSeparatorMax.x + (8 - halfBorderWidth), headerSeparatorMin.y - 0.5f),
+                    ImVec2(HeaderMin.x - (8 - halfBorderWidth), HeaderMax.y  -0.5f),
+                    ImVec2(HeaderMax.x + (8 - halfBorderWidth), HeaderMax.y - 0.5f),
                     ImColor(255, 255, 255, 96 * alpha / (3 * 255)), 1.0f);
             }
         }

--- a/examples/blueprints-example/utilities/builders.cpp
+++ b/examples/blueprints-example/utilities/builders.cpp
@@ -74,13 +74,13 @@ void util::BlueprintNodeBuilder::End()
 
 
             auto headerSeparatorMin = ImVec2(HeaderMin.x, HeaderMax.y);
-            auto headerSeparatorMax = ImVec2(HeaderMax.x, HeaderMin.y);
+            auto headerSeparatorMax = ImVec2(ContentMax.x, ContentMin.y);
 
             if ((headerSeparatorMax.x > headerSeparatorMin.x) && (headerSeparatorMax.y > headerSeparatorMin.y))
             {
                 drawList->AddLine(
-                    headerSeparatorMin + ImVec2(-(8 - halfBorderWidth), -0.5f),
-                    headerSeparatorMax + ImVec2( (8 - halfBorderWidth), -0.5f),
+                    ImVec2(headerSeparatorMin.x - (8 - halfBorderWidth), headerSeparatorMin.y  -0.5f),
+                    ImVec2(headerSeparatorMax.x + (8 - halfBorderWidth), headerSeparatorMin.y - 0.5f),
                     ImColor(255, 255, 255, 96 * alpha / (3 * 255)), 1.0f);
             }
         }


### PR DESCRIPTION
The refactoring in commit commit 2d5864dc83cfb06d39e526a094d6e989f5dd69d7 broke both the calculation of the separator rectangle and the calculation of the `p2.y` argument in the following `AddLine` call.

While at it, I realized that after the refactoring the calculation is now unnecessarily complicated, so I simplified it.