### PR TITLE
cmake modular installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.24)
+Project(imgui_node_editor)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/misc/cmake-modules)
+
+set(IMGUI_NODE_EDITOR_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+add_subdirectory(${IMGUI_NODE_EDITOR_ROOT_DIR}/examples/application)
+
+find_package(imgui REQUIRED)
+
+set(${PROJECT_NAME}_Sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/crude_json.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui_bezier_math.inl
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui_canvas.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui_extra_math.inl
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui_node_editor_api.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui_node_editor_internal.inl
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui_node_editor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/misc/imgui_node_editor.natvis
+)
+
+set(${PROJECT_NAME}_Headers
+    ${CMAKE_CURRENT_SOURCE_DIR}/crude_json.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui_bezier_math.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui_canvas.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui_extra_math.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui_node_editor_internal.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui_node_editor.h
+)
+
+add_library(${PROJECT_NAME} STATIC ${${PROJECT_NAME}_Sources} ${${PROJECT_NAME}_Headers})
+
+target_include_directories(${PROJECT_NAME} PUBLIC 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/>
+)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC imgui)
+target_link_directories(${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:lib>)
+
+install(
+    TARGETS         ${PROJECT_NAME} imgui application stb_image ScopeGuard
+    EXPORT          Targets
+)
+
+if(WIN32)
+install(
+    FILES       external/DXSDK/lib/x64/d3dx11.lib
+    DESTINATION lib
+)
+endif()
+
+install(
+    FILES       ${${PROJECT_NAME}_Headers}
+    DESTINATION include/${PROJECT_NAME}
+)
+
+install(
+    EXPORT      Targets
+    FILE        ${PROJECT_NAME}Config.cmake
+    NAMESPACE   ${PROJECT_NAME}::
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
+)

--- a/examples/application/CMakeLists.txt
+++ b/examples/application/CMakeLists.txt
@@ -1,10 +1,10 @@
 project(application)
 
 set(_Application_Sources
-    include/application.h
-    source/application.cpp
-    source/entry_point.cpp
-    source/imgui_extra_keys.h
+include/application.h
+source/application.cpp
+source/entry_point.cpp
+source/imgui_extra_keys.h
     source/config.h.in
     source/setup.h
     source/platform.h
@@ -13,11 +13,14 @@ set(_Application_Sources
     source/renderer.h
     source/renderer_dx11.cpp
     source/renderer_ogl3.cpp
-)
-
+    )
+    
 add_library(application STATIC)
 
-target_include_directories(application PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(application PUBLIC 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/application>
+)
 
 find_package(imgui REQUIRED)
 find_package(stb_image REQUIRED)
@@ -110,3 +113,8 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${_Application_Sources})
 target_sources(application PRIVATE ${_Application_Sources})
 
 set_property(TARGET application PROPERTY FOLDER "examples")
+
+install(
+    FILES       ${CMAKE_CURRENT_SOURCE_DIR}/include/application.h
+    DESTINATION include/application
+    )

--- a/external/ScopeGuard/CMakeLists.txt
+++ b/external/ScopeGuard/CMakeLists.txt
@@ -6,7 +6,7 @@ set(_ScopeGuard_Sources
     ${CMAKE_CURRENT_SOURCE_DIR}/ScopeGuard.h
 )
 
-target_include_directories(ScopeGuard INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_sources(ScopeGuard INTERFACE ${_ScopeGuard_Sources})
+target_include_directories(ScopeGuard INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+target_sources(ScopeGuard INTERFACE $<BUILD_INTERFACE:${_ScopeGuard_Sources}>)
 
 source_group("ThirdParty\\ScopeGuard" FILES ${_ScopeGuard_Sources})

--- a/external/imgui/CMakeLists.txt
+++ b/external/imgui/CMakeLists.txt
@@ -1,24 +1,31 @@
 project(imgui VERSION 1.76)
 
 set(_imgui_Sources
-    imconfig.h
     imgui.cpp
-    imgui.h
     imgui.natvis
     imgui_demo.cpp
     imgui_draw.cpp
-    imgui_internal.h
     imgui_widgets.cpp
     imgui_tables.cpp
-    imstb_rectpack.h
-    imstb_textedit.h
-    imstb_truetype.h
     LICENSE.txt
 )
 
-add_library(${PROJECT_NAME} STATIC ${_imgui_Sources})
+set(_imgui_headers
+imconfig.h
+imgui.h
+imgui_internal.h
+imstb_rectpack.h
+imstb_textedit.h
+imstb_truetype.h
+)
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(${PROJECT_NAME} STATIC ${_imgui_Sources} ${_imgui_headers})
+
+target_include_directories(${PROJECT_NAME} INTERFACE 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}/>
+)
+
 #target_compile_definitions(${PROJECT_NAME} PUBLIC "ImDrawIdx=unsigned int")
 target_compile_definitions(${PROJECT_NAME} PUBLIC IMGUI_DISABLE_OBSOLETE_FUNCTIONS)
 
@@ -26,3 +33,9 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${_imgui_Sources})
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER "external")
 
+install(
+    FILES
+        ${_imgui_headers}
+    DESTINATION
+        include/${PROJECT_NAME}    
+)

--- a/external/stb_image/CMakeLists.txt
+++ b/external/stb_image/CMakeLists.txt
@@ -6,7 +6,8 @@ set(_stb_image_Sources
     ${CMAKE_CURRENT_SOURCE_DIR}/stb_image.h
 )
 
-target_include_directories(stb_image INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_sources(stb_image INTERFACE ${_stb_image_Sources})
+target_include_directories(stb_image INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+target_sources(stb_image INTERFACE $<BUILD_INTERFACE:${_stb_image_Sources}>)
 
 source_group("ThirdParty\\stb_image" FILES ${_stb_image_Sources})


### PR DESCRIPTION
I'm not sure weather this change helps or interrupts.

It's definitely not finished and needs work but I require some help with that since I'm still new to CMake.

Main reason I made these changes was to build my application in elegant way.
I wanted to use your "application" class as starting point but I didn't want to wire CMakes to build directory.

After introducing changes, building and installing.
Integration with imgui-node-editor looks like this.
![image](https://user-images.githubusercontent.com/40217160/202874578-37195e97-9a28-4381-9040-716d9a45f28e.png)
![image](https://user-images.githubusercontent.com/40217160/202874604-2479d857-69a1-4b3e-9300-3f53fa5a6e27.png)

Unfortunately I couldn't come up with solution to PUBLIC include directories.
From my understanding mere linking to imgui_node_editor::imgui_node_editor should make them visible
for the project but It doesn't. Hence ${CMAKE_INSTALL_PREFIX}/../imgui_...
