### PR TITLE
[Add] Suspend/Resume Canvas Zoom by desactivating Navigation  

### DIFF
--- a/imgui_node_editor.h
+++ b/imgui_node_editor.h
@@ -368,6 +368,9 @@ int BreakLinks(PinId pinId); // Break all links connected to this pin
 void NavigateToContent(float duration = -1);
 void NavigateToSelection(bool zoomIn = false, float duration = -1);
 
+void SuspendNavigation();
+void ResumeNavigation();
+
 bool ShowNodeContextMenu(NodeId* nodeId);
 bool ShowPinContextMenu(PinId* pinId);
 bool ShowLinkContextMenu(LinkId* linkId);

--- a/imgui_node_editor_api.cpp
+++ b/imgui_node_editor_api.cpp
@@ -576,6 +576,16 @@ void ax::NodeEditor::NavigateToSelection(bool zoomIn, float duration)
     s_Editor->NavigateTo(s_Editor->GetSelectionBounds(), zoomIn, duration);
 }
 
+void ax::NodeEditor::SuspendNavigation()
+{
+    s_Editor->SuspendNavigation();
+}
+
+void ax::NodeEditor::ResumeNavigation()
+{
+    s_Editor->ResumeNavigation();
+}
+
 bool ax::NodeEditor::ShowNodeContextMenu(NodeId* nodeId)
 {
     return s_Editor->GetContextMenu().ShowNodeContextMenu(nodeId);

--- a/imgui_node_editor_internal.h
+++ b/imgui_node_editor_internal.h
@@ -1433,6 +1433,16 @@ struct EditorContext
         m_NavigateAction.NavigateTo(bounds, zoomMode, duration);
     }
 
+    inline void SuspendNavigation()
+    {
+        m_NavigateAction.m_IsActive = false;
+    }
+
+    inline void ResumeNavigation()
+    {
+        m_NavigateAction.m_IsActive = true;
+    }
+
     void RegisterAnimation(Animation* animation);
     void UnregisterAnimation(Animation* animation);
 


### PR DESCRIPTION
## Major:
- Using NavigateAction::m_IsActive boolean (m_NavigateAction of the EditorContext)
- Added methods To gloabal API to directly set it to true (ResumeNavigation) or false (SuspendNavigation).
- As a result, we can call the couple Suspend/Resume to momentarily deactivate the canvas zoom.

## Use Case Example
When hovering over a ListBox (this is a custom to my project), I can call `ax::NodeEditor::SuspendNavigation()` before a portion of code that wants to use the `ImGui::GetIO().MouseWheel` input. Then, I call `ax::NodeEditor::ResumeNavigation()`.

Pseudo-code
```c++
if (isListBoxHovered())
{
    ax::NodeEditor::SuspendNavigation();
    
    //handle list box scrolling
    
    ax::NodeEditor::ResumeNavigation();
}
``` 

![NodeEditorZoomSuspendResume](https://user-images.githubusercontent.com/56084809/235633830-6642e32d-34d4-4f22-9129-bd6700e6635e.gif)
