### PR TITLE
Added missing include of <cstdint> for type intptr_t

### DIFF
--- a/examples/application/source/renderer_ogl3.cpp
+++ b/examples/application/source/renderer_ogl3.cpp
@@ -4,6 +4,7 @@
 
 # include "platform.h"
 # include <algorithm>
+# include <cstdint>
 
 # if PLATFORM(WINDOWS)
 #     define NOMINMAX


### PR DESCRIPTION
The example 'application' is failing to build under linux gcc in its current form, as the compiler was unable to find the type std::intptr_t. To fix this issue and to comply with the c++ standard I've added an include to \<cstdint\>.