### PR TITLE
Add a way to specify custom id types 

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,8 +23,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED   YES)
 macro(add_example_executable name)
     project(${name})
 
+    set(options NOLINK)
+    set(oneValueArgs)
+    set(multiValueArgs SOURCES)
+    cmake_parse_arguments(ADD_EXAMPLE "${options}" "${oneValueArgs}"
+                          "${multiValueArgs}" ${ARGN})
+
     set(_Example_Sources
-        ${ARGN}
+        ${ADD_EXAMPLE_SOURCES}
     )
 
     #source_group("" FILES ${_Example_Sources})
@@ -69,7 +75,10 @@ macro(add_example_executable name)
 
     find_package(imgui REQUIRED)
     find_package(imgui_node_editor REQUIRED)
-    target_link_libraries(${name} PRIVATE imgui imgui_node_editor application)
+    target_link_libraries(${name} PRIVATE imgui application)
+    if (NOT ADD_EXAMPLE_NOLINK)
+        target_link_libraries(${name} PRIVATE imgui_node_editor)
+    endif()
 
     set(_ExampleBinDir ${CMAKE_BINARY_DIR}/bin)
 
@@ -132,3 +141,4 @@ add_subdirectory(simple-example)
 add_subdirectory(widgets-example)
 add_subdirectory(basic-interaction-example)
 add_subdirectory(blueprints-example)
+add_subdirectory(idtypes-example)

--- a/examples/application/source/renderer_ogl3.cpp
+++ b/examples/application/source/renderer_ogl3.cpp
@@ -4,6 +4,7 @@
 
 # include "platform.h"
 # include <algorithm>
+# include <cstdint>
 
 # if PLATFORM(WINDOWS)
 #     define NOMINMAX

--- a/examples/basic-interaction-example/CMakeLists.txt
+++ b/examples/basic-interaction-example/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_example_executable(basic-interaction-example
-    basic-interaction-example.cpp
+    SOURCES basic-interaction-example.cpp
 )

--- a/examples/blueprints-example/CMakeLists.txt
+++ b/examples/blueprints-example/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_example_executable(blueprints-example
+add_example_executable(blueprints-example SOURCES
     blueprints-example.cpp
     utilities/builders.h
     utilities/drawing.h

--- a/examples/canvas-example/CMakeLists.txt
+++ b/examples/canvas-example/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_example_executable(canvas-example
+add_example_executable(canvas-example SOURCES
     canvas-example.cpp
 )
 

--- a/examples/idtypes-example/CMakeLists.txt
+++ b/examples/idtypes-example/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_example_executable(idtypes-example NOLINK
+    SOURCES idtypes-example.cpp
+)
+
+set(CMAKE_CXX_STANDARD            14)
+set(CMAKE_CXX_STANDARD_REQUIRED   YES)
+
+add_library(imgui_node_editor_customids STATIC
+    ${IMGUI_NODE_EDITOR_SOURCES}
+)
+
+target_include_directories(imgui_node_editor_customids PUBLIC
+    ${IMGUI_NODE_EDITOR_ROOT_DIR}
+)
+
+target_link_libraries(imgui_node_editor_customids PUBLIC imgui)
+
+target_compile_definitions(imgui_node_editor_customids PUBLIC IMGUI_NODE_EDITOR_USER_CONFIG="${CMAKE_CURRENT_SOURCE_DIR}/edconfig.h")
+target_link_libraries(idtypes-example PRIVATE imgui_node_editor_customids)

--- a/examples/idtypes-example/edconfig.h
+++ b/examples/idtypes-example/edconfig.h
@@ -1,0 +1,67 @@
+#ifndef EDCONFIG_H
+#define EDCONFIG_H
+
+#include <string>
+
+struct CustomNodeId
+{
+    std::string name;
+
+    CustomNodeId(const CustomNodeId &id) = default;
+    CustomNodeId &operator=(const CustomNodeId &id) = default;
+
+    bool operator<(const CustomNodeId &id) const;
+    bool operator==(const CustomNodeId &id) const;
+
+    std::string AsString() const;
+    static CustomNodeId FromString(const char *str, const char *end);
+    bool IsValid() const;
+
+    static const CustomNodeId Invalid;
+};
+
+struct CustomPinId
+{
+    enum class Direction {
+        In,
+        Out
+    };
+    std::string nodeName;
+    Direction direction;
+    int pinIndex;
+
+    CustomPinId(const CustomPinId &id) = default;
+    CustomPinId &operator=(const CustomPinId &id) = default;
+
+    bool operator<(const CustomPinId &id) const;
+    bool operator==(const CustomPinId &id) const;
+
+    std::string AsString() const;
+    static CustomPinId FromString(const char *str, const char *end);
+    bool IsValid() const;
+
+    static const CustomPinId Invalid;
+};
+
+struct CustomLinkId
+{
+    CustomPinId in, out;
+
+    CustomLinkId(const CustomLinkId &id) = default;
+    CustomLinkId &operator=(const CustomLinkId &id) = default;
+
+    bool operator<(const CustomLinkId &id) const;
+    bool operator==(const CustomLinkId &id) const;
+
+    std::string AsString() const;
+    static CustomLinkId FromString(const char *str, const char *end);
+    bool IsValid() const;
+
+    static const CustomLinkId Invalid;
+};
+
+#define IMGUI_NODE_EDITOR_CUSTOM_NODEID CustomNodeId
+#define IMGUI_NODE_EDITOR_CUSTOM_PINID CustomPinId
+#define IMGUI_NODE_EDITOR_CUSTOM_LINKID CustomLinkId
+
+#endif

--- a/examples/idtypes-example/idtypes-example.cpp
+++ b/examples/idtypes-example/idtypes-example.cpp
@@ -1,0 +1,212 @@
+﻿# include <imgui.h>
+# include <imgui_node_editor.h>
+# include <application.h>
+# include <vector>
+# include <unordered_map>
+
+#include "edconfig.h"
+
+namespace ed = ax::NodeEditor;
+
+struct Pin
+{
+};
+
+struct Node
+{
+    std::vector<Pin> InPins;
+    std::vector<Pin> OutPins;
+};
+
+bool CustomNodeId::operator<(const CustomNodeId &id) const
+{
+    return name < id.name;
+}
+
+bool CustomNodeId::operator==(const CustomNodeId &id) const
+{
+    return name == id.name;
+}
+
+std::string CustomNodeId::AsString() const
+{
+    return name;
+}
+
+CustomNodeId CustomNodeId::FromString(const char *str, const char *end)
+{
+    return CustomNodeId{ std::string(str, end) };
+}
+
+bool CustomNodeId::IsValid() const
+{
+    return !name.empty();
+}
+
+const CustomNodeId CustomNodeId::Invalid = {};
+
+bool CustomPinId::operator<(const CustomPinId &id) const
+{
+    if (nodeName < id.nodeName) return true;
+    else if (nodeName > id.nodeName) return false;
+
+    if (int(direction) < int(id.direction)) return true;
+    else if (int(direction) > int(id.direction)) return false;
+
+    return pinIndex < id.pinIndex;
+}
+
+bool CustomPinId::operator==(const CustomPinId &id) const
+{
+    return nodeName == id.nodeName && direction == id.direction && pinIndex == id.pinIndex;
+}
+
+std::string CustomPinId::AsString() const
+{
+    return nodeName + ";" + std::to_string(int(direction)) + ";" + std::to_string(pinIndex);
+}
+
+CustomPinId CustomPinId::FromString(const char *str, const char *end)
+{
+    std::string string(str, end);
+    auto sep1 = string.find(';');
+
+    if (sep1 == 0 || sep1 == std::string::npos) {
+        return Invalid;
+    }
+
+    auto sep2 = string.find(';', sep1 + 1);
+    if (sep2 == sep1 + 1 || sep2 == std::string::npos) {
+        return Invalid;
+    }
+
+    char *e;
+    auto nodeName = std::string(string.data(), sep1);
+    int dir = std::strtol(string.data() + sep1 + 1, &e, 10);
+    if (dir > 1) {
+        return Invalid;
+    }
+
+    int pin = std::strtol(string.data() + sep2 + 1, &e, 10);
+    return CustomPinId{ nodeName, CustomPinId::Direction(dir), pin };
+}
+
+bool CustomPinId::IsValid() const
+{
+    return !nodeName.empty();
+}
+
+const CustomPinId CustomPinId::Invalid = {};
+
+
+bool CustomLinkId::operator<(const CustomLinkId &id) const
+{
+    if (in < id.in) return true;
+    if (in == id.in) return out < id.out;
+    return false;
+}
+
+bool CustomLinkId::operator==(const CustomLinkId &id) const
+{
+    return in == id.in && out == id.out;
+}
+
+std::string CustomLinkId::AsString() const
+{
+    return in.AsString() + "->" + out.AsString();
+}
+
+CustomLinkId CustomLinkId::FromString(const char *str, const char *end)
+{
+    std::string string(str, end);
+    auto sep = string.find("->");
+    if (sep == 0 || sep == std::string::npos) {
+        return Invalid;
+    }
+
+    auto in = CustomPinId::FromString(str, str + sep);
+    auto out = CustomPinId::FromString(str + sep + 2, end);
+    return { in, out };
+}
+
+bool CustomLinkId::IsValid() const
+{
+    return in.IsValid() && out.IsValid();
+}
+
+const CustomLinkId CustomLinkId::Invalid = {};
+
+struct Example:
+    public Application
+{
+    using Application::Application;
+
+    void OnStart() override
+    {
+        ed::Config config;
+        config.SettingsFile = "IdTypes.json";
+        m_Context = ed::CreateEditor(&config);
+
+        m_Nodes.insert({ "foo", Node{ { {}, {} }, { {} } } });
+        m_Nodes.insert({ "bar", Node{ { {} }, { {}, {}, {} } } });
+    }
+
+    void OnStop() override
+    {
+        ed::DestroyEditor(m_Context);
+    }
+
+    void OnFrame(float deltaTime) override
+    {
+        auto& io = ImGui::GetIO();
+
+        ImGui::Text("FPS: %.2f (%.2gms)", io.Framerate, io.Framerate ? 1000.0f / io.Framerate : 0.0f);
+
+        ImGui::Separator();
+
+        ed::SetCurrentEditor(m_Context);
+        ed::Begin("My Editor", ImVec2(0.0, 0.0f));
+        // Start drawing nodes.
+        for (auto &n: m_Nodes) {
+            ed::BeginNode(CustomNodeId{ n.first });
+                ImGui::TextUnformatted(n.first.c_str());
+
+                ImGui::BeginGroup();
+                for (int i = 0; i < n.second.InPins.size(); ++i) {
+                    ed::BeginPin(CustomPinId{ n.first, CustomPinId::Direction::In, i }, ed::PinKind::Input);
+                        ImGui::Text("-> In");
+                    ed::EndPin();
+                }
+                ImGui::EndGroup();
+
+                ImGui::SameLine();
+
+                ImGui::BeginGroup();
+                for (int i = 0; i < n.second.OutPins.size(); ++i) {
+                    ed::BeginPin(CustomPinId{ n.first, CustomPinId::Direction::Out, i }, ed::PinKind::Output);
+                        ImGui::Text("Out ->");
+                    ed::EndPin();
+                }
+                ImGui::EndGroup();
+
+            ed::EndNode();
+        }
+        ed::End();
+        ed::SetCurrentEditor(nullptr);
+
+	    //ImGui::ShowMetricsWindow();
+    }
+
+    ed::EditorContext* m_Context = nullptr;
+    std::unordered_map<std::string, Node> m_Nodes;
+};
+
+int Main(int argc, char** argv)
+{
+    Example exampe("IdTypes", argc, argv);
+
+    if (exampe.Create())
+        return exampe.Run();
+
+    return 0;
+}

--- a/examples/simple-example/CMakeLists.txt
+++ b/examples/simple-example/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_example_executable(simple-example
+add_example_executable(simple-example SOURCES
     simple-example.cpp
 )

--- a/examples/widgets-example/CMakeLists.txt
+++ b/examples/widgets-example/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_example_executable(widgets-example
+add_example_executable(widgets-example SOURCES
     widgets-example.cpp
 )

--- a/imgui_node_editor.h
+++ b/imgui_node_editor.h
@@ -24,6 +24,9 @@
 # define IMGUI_NODE_EDITOR_VERSION      "0.9.2"
 # define IMGUI_NODE_EDITOR_VERSION_NUM  000902
 
+#ifdef IMGUI_NODE_EDITOR_USER_CONFIG
+#include IMGUI_NODE_EDITOR_USER_CONFIG
+#endif
 
 //------------------------------------------------------------------------------
 namespace ax {
@@ -31,9 +34,23 @@ namespace NodeEditor {
 
 
 //------------------------------------------------------------------------------
+#ifdef IMGUI_NODE_EDITOR_CUSTOM_NODEID
+using NodeId = IMGUI_NODE_EDITOR_CUSTOM_NODEID;
+#else
 struct NodeId;
+#endif
+
+#ifdef IMGUI_NODE_EDITOR_CUSTOM_LINKID
+using LinkId = IMGUI_NODE_EDITOR_CUSTOM_LINKID;
+#else
 struct LinkId;
+#endif
+
+#ifdef IMGUI_NODE_EDITOR_CUSTOM_PINID
+using PinId = IMGUI_NODE_EDITOR_CUSTOM_PINID;
+#else
 struct PinId;
+#endif
 
 
 //------------------------------------------------------------------------------
@@ -465,7 +482,11 @@ struct SafePointerType
     template <typename T = void> explicit SafePointerType(T* ptr): SafePointerType(reinterpret_cast<uintptr_t>(ptr)) {}
     template <typename T = void> T* AsPointer() const { return reinterpret_cast<T*>(this->Get()); }
 
+    inline bool IsValid() const { return *this != Invalid; }
+
     explicit operator bool() const { return *this != Invalid; }
+
+    inline bool operator<(Tag o) const { return AsPointer() < o.AsPointer(); }
 };
 
 template <typename Tag>
@@ -485,20 +506,26 @@ inline bool operator!=(const SafePointerType<Tag>& lhs, const SafePointerType<Ta
 
 } // namespace Details
 
+#ifndef IMGUI_NODE_EDITOR_CUSTOM_NODEID
 struct NodeId final: Details::SafePointerType<NodeId>
 {
     using SafePointerType::SafePointerType;
 };
+#endif
 
+#ifndef IMGUI_NODE_EDITOR_CUSTOM_LINKID
 struct LinkId final: Details::SafePointerType<LinkId>
 {
     using SafePointerType::SafePointerType;
 };
+#endif
 
+#ifndef IMGUI_NODE_EDITOR_CUSTOM_PINID
 struct PinId final: Details::SafePointerType<PinId>
 {
     using SafePointerType::SafePointerType;
 };
+#endif
 
 
 //------------------------------------------------------------------------------

--- a/imgui_node_editor_api.cpp
+++ b/imgui_node_editor_api.cpp
@@ -31,7 +31,7 @@ static int BuildIdList(C& container, I* list, int listSize, F&& accept)
 
             if (accept(object))
             {
-                list[count] = I(object->ID().AsPointer());
+                list[count] = I(object->ID());
                 ++count;
                 --listSize;}
         }

--- a/misc/cmake-modules/Findimgui_node_editor.cmake
+++ b/misc/cmake-modules/Findimgui_node_editor.cmake
@@ -36,6 +36,8 @@ target_include_directories(imgui_node_editor PUBLIC
     ${IMGUI_NODE_EDITOR_ROOT_DIR}
 )
 
+set(IMGUI_NODE_EDITOR_SOURCES ${_imgui_node_editor_Sources} PARENT_SCOPE)
+
 target_link_libraries(imgui_node_editor PUBLIC imgui)
 
 source_group(TREE ${IMGUI_NODE_EDITOR_ROOT_DIR} FILES ${_imgui_node_editor_Sources})


### PR DESCRIPTION
NodeId, LinkId and PinId are just glorified pointers. In some cases
32/64 bits of data may not be enough to identify an object, or the
objects may lack a stable pointer/id value.
This commit adds a way to specify custom data types for them:
similarly to ImGui, a IMGUI_NODE_EDITOR_USER_CONFIG macro can be set
before including imgui_node_editor.h. If defined, its value will be
used as a filename to be included at the top of imgui_node_editor.h.

In it, the macros IMGUI_NODE_EDITOR_CUSTOM_NODEID,
IMGUI_NODE_EDITOR_CUSTOM_PINID and IMGUI_NODE_EDITOR_CUSTOM_LINKID
may be defined as the names of the types to be used for them.
If one or more of them are not defined the old types will be used,
old code does not need to be changed.

The types used must be copy contructible, assignable and must provide
a few more functions, as in this example:
struct CustomId
{
    CustomId(const CustomId &id);
    CustomId &operator=(const CustomId &id);;

    bool operator<(const CustomId &id) const;
    bool operator==(const CustomId &id) const;;

    std::string AsString() const;
    static CustomId FromString(const char *str, const char *end);
    bool IsValid() const;

    static const CustomId Invalid;
};

A new example showcasing the functionality is added.