### PR TITLE
Fix: don't respond to mouse drag events that started outside of our nodes window

### DIFF
--- a/imgui_node_editor.cpp
+++ b/imgui_node_editor.cpp
@@ -3304,7 +3304,10 @@ ed::EditorAction::AcceptResult ed::NavigateAction::Accept(const Control& control
     if (m_IsActive)
         return False;
 
-    if (Editor->CanAcceptUserInput() /*&& !ImGui::IsAnyItemActive()*/ && ImGui::IsMouseDragging(Editor->GetConfig().NavigateButtonIndex, 0.0f))
+    if (Editor->CanAcceptUserInput() /*&& !ImGui::IsAnyItemActive()*/
+        && ImGui::IsMouseDragging(Editor->GetConfig().NavigateButtonIndex, 0.0f)
+        && !ImGui::IsMouseDragPastThreshold(Editor->GetConfig().NavigateButtonIndex) // Make sure that if the dragging started in another window, we don't pick it up.
+    )
     {
         m_IsActive    = true;
         m_ScrollStart = m_Scroll;


### PR DESCRIPTION
When you start dragging the mouse in a window not related to the nodes, and then hover the nodes window while dragging, the nodes view starts panning:

![Animation1](https://github.com/thedmd/imgui-node-editor/assets/45451201/c37867f1-8802-4b6c-81b0-0913012de5cf)

This PR fixes it and only allows drag events that started in the nodes window to affect the nodes view:

![Animation2](https://github.com/thedmd/imgui-node-editor/assets/45451201/68d2a792-7ef4-4dd4-b2bb-f380fa906e2e)
