### PR TITLE
Replace SentinelDrawCallback with a define

### DIFF
--- a/imgui_canvas.cpp
+++ b/imgui_canvas.cpp
@@ -27,6 +27,11 @@
         static constexpr bool value = (sizeof(yes_type) == sizeof(test<mixin>(0)));  \
     }
 
+// Special sentinel value. This needs to be unique, so allow it to be overidden in the user's imgui config
+#ifndef ImDrawCallback_NodeEditorCanvas
+#define ImDrawCallback_NodeEditorCanvas     (ImDrawCallback)(-2)
+#endif
+
 namespace ImCanvasDetails {
 
 DECLARE_HAS_MEMBER(HasFringeScale, _FringeScale);
@@ -67,12 +72,6 @@ struct VtxCurrentOffsetRef
         return drawList->_CmdHeader.VtxOffset;
     }
 };
-
-static void SentinelDrawCallback(const ImDrawList* parent_list, const ImDrawCmd* cmd)
-{
-    // This is a sentinel draw callback, it's only purpose is to mark draw list command.
-    IM_ASSERT(false && "This draw callback should never be called.");
-}
 
 } // namespace ImCanvasDetails
 
@@ -435,7 +434,7 @@ void ImGuiEx::Canvas::EnterLocalSpace()
     //
     //     More investigation is needed. To get to the bottom of this.
     if ((!m_DrawList->CmdBuffer.empty() && m_DrawList->CmdBuffer.back().ElemCount > 0) || m_DrawList->_Splitter._Count > 1)
-        m_DrawList->AddCallback(&ImCanvasDetails::SentinelDrawCallback, nullptr);
+        m_DrawList->AddCallback(ImDrawCallback_NodeEditorCanvas, nullptr);
 
 # if IMGUI_EX_CANVAS_DEFERED()
     m_Ranges.resize(m_Ranges.Size + 1);
@@ -554,7 +553,7 @@ void ImGuiEx::Canvas::LeaveLocalSpace()
     }
 
     // Remove sentinel draw command if present
-    if (m_DrawListCommadBufferSize > 0 && m_DrawList->CmdBuffer.size() >= m_DrawListCommadBufferSize && m_DrawList->CmdBuffer[m_DrawListCommadBufferSize - 1].UserCallback == &ImCanvasDetails::SentinelDrawCallback)
+    if (m_DrawListCommadBufferSize > 0 && m_DrawList->CmdBuffer.size() >= m_DrawListCommadBufferSize && m_DrawList->CmdBuffer[m_DrawListCommadBufferSize - 1].UserCallback == ImDrawCallback_NodeEditorCanvas)
         m_DrawList->CmdBuffer.erase(m_DrawList->CmdBuffer.Data + m_DrawListCommadBufferSize - 1);
 
     auto& fringeScale = ImFringeScaleRef(m_DrawList);


### PR DESCRIPTION
This mirrors the way ImGui does it (See also ImDrawCallback_ResetRenderState).

The primary motivation here is that it's possible to override the type of ImDrawCallback in the implementation, so any extension code needs to allow for whatever zany types the implementer may choose. (In our case, vclosure*)

With this change, the type should always be compatible, and we additionally support implementation overrides should some other extension or internal code be sitting on that sentinel value already in a way that would cause a conflict.