### PR TITLE
ci: Update to `actions/checkout@v4`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       MSBUILD_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Configure CMake
       run: cmake -S examples -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
     - name: Build
@@ -39,7 +39,7 @@ jobs:
     - name: Install Dependencies
       run: |
         brew install glfw3    
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Configure CMake
       run: cmake -S examples -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
     - name: Build
@@ -53,7 +53,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libglfw3-dev    
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Configure CMake
       run: cmake -S examples -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
     - name: Build


### PR DESCRIPTION
This fixes deprecation warnings within GitHub Actions due to using an old version of Node.