### PR TITLE
Adding support for modern dear imgui versions

### DIFF
--- a/imgui_node_editor.cpp
+++ b/imgui_node_editor.cpp
@@ -35,6 +35,24 @@
         static bool const value = sizeof(test<T>(0)) == sizeof(yes);               \
     };
 
+// LOCAL NAMESPACE TO DEFINE FLOOR FUNCTION, deprecated in imgui
+namespace {
+    void FloorRect(ImRect & rect) {
+        rect.Min.x = IM_TRUNC(rect.Min.x);
+        rect.Min.y = IM_TRUNC(rect.Min.y);
+        rect.Max.x = IM_TRUNC(rect.Max.x);
+        rect.Max.y = IM_TRUNC(rect.Max.y);
+    }
+}
+namespace ImGui {
+    ImGuiKey GetKeyIndex(ImGuiKey key)
+    {
+        IM_ASSERT(IsNamedKey(key));
+        return key; // already the correct 'index' in modern ImGui
+    }
+}
+
+
 
 namespace ax {
 namespace NodeEditor {
@@ -1648,7 +1666,7 @@ void ed::EditorContext::SetNodePosition(NodeId nodeId, const ImVec2& position)
     if (node->m_Bounds.Min != position)
     {
         node->m_Bounds.Translate(position - node->m_Bounds.Min);
-        node->m_Bounds.Floor();
+        FloorRect(node->m_Bounds);
         MakeDirty(NodeEditor::SaveReasonFlags::Position, node);
     }
 }
@@ -1668,7 +1686,7 @@ void ed::EditorContext::SetGroupSize(NodeId nodeId, const ImVec2& size)
     {
         node->m_GroupBounds.Min = node->m_Bounds.Min;
         node->m_GroupBounds.Max = node->m_Bounds.Min + size;
-        node->m_GroupBounds.Floor();
+        FloorRect(node->m_GroupBounds);
         MakeDirty(NodeEditor::SaveReasonFlags::Size, node);
     }
 }
@@ -1746,10 +1764,10 @@ void ed::EditorContext::UpdateNodeState(Node* node)
 
     node->m_Bounds.Min      = settings->m_Location;
     node->m_Bounds.Max      = node->m_Bounds.Min + settings->m_Size;
-    node->m_Bounds.Floor();
+    FloorRect(node->m_Bounds);
     node->m_GroupBounds.Min = settings->m_Location;
     node->m_GroupBounds.Max = node->m_GroupBounds.Min + settings->m_GroupSize;
-    node->m_GroupBounds.Floor();
+    FloorRect(node->m_GroupBounds);
 }
 
 void ed::EditorContext::RemoveSettings(Object* object)
@@ -3799,7 +3817,7 @@ bool ed::SizeAction::Process(const Control& control)
         if ((m_Pivot & NodeRegion::Right) == NodeRegion::Right)
             newBounds.Max.x = ImMax(newBounds.Min.x + minimumSize.x, Editor->AlignPointToGrid(newBounds.Max.x + dragOffset.x));
 
-        newBounds.Floor();
+        FloorRect(newBounds);
 
         m_LastSize = newBounds.GetSize();
 
@@ -5309,7 +5327,7 @@ void ed::NodeBuilder::End()
     ImGui::EndGroup();
 
     m_NodeRect = ImGui_GetItemRect();
-    m_NodeRect.Floor();
+    FloorRect(m_NodeRect);
 
     if (m_CurrentNode->m_Bounds.GetSize() != m_NodeRect.GetSize())
     {
@@ -5417,7 +5435,7 @@ void ed::NodeBuilder::PinRect(const ImVec2& a, const ImVec2& b)
     IM_ASSERT(nullptr != m_CurrentPin);
 
     m_CurrentPin->m_Bounds = ImRect(a, b);
-    m_CurrentPin->m_Bounds.Floor();
+    FloorRect(m_CurrentPin->m_Bounds);
     m_ResolvePinRect     = false;
 }
 
@@ -5467,7 +5485,7 @@ void ed::NodeBuilder::Group(const ImVec2& size)
         ImGui::Dummy(size);
 
     m_GroupBounds = ImGui_GetItemRect();
-    m_GroupBounds.Floor();
+    FloorRect(m_GroupBounds);
 }
 
 ImDrawList* ed::NodeBuilder::GetUserBackgroundDrawList() const

--- a/imgui_node_editor.cpp
+++ b/imgui_node_editor.cpp
@@ -37,7 +37,8 @@
 
 // LOCAL NAMESPACE TO DEFINE FLOOR FUNCTION, deprecated in imgui
 namespace {
-    void FloorRect(ImRect & rect) {
+    void FloorRect(ImRect & rect)
+    {
         rect.Min.x = IM_TRUNC(rect.Min.x);
         rect.Min.y = IM_TRUNC(rect.Min.y);
         rect.Max.x = IM_TRUNC(rect.Max.x);


### PR DESCRIPTION
Both the master branch and the PR https://github.com/thedmd/imgui-node-editor/pull/326 from @NGLSG do not compile with the latest dear imgui releases

# Tested on

Dear ImGui Commit ad76935
https://github.com/ocornut/imgui/commit/ad769352ea0d15459b1bcfd35f8afb33f6e5d2a3

# Solves

Deprecation of `GetKeyData(key);` function used by NGLSG
` const ImGuiKeyData* key_data = GetKeyData(key);`

```
ImGuiKeyData* ImGui::GetKeyData(ImGuiContext*, ImGuiKey): Assertion `IsNamedKey(key) && "Support for user key indices was dropped in favor of ImGuiKey. Please update backend & user code."' failed.
```

And the removal of the ImRect Floor function


