### PR TITLE
Fix: widgets in a back node steal hover/click from the front node

### DIFF
--- a/imgui_node_editor.cpp
+++ b/imgui_node_editor.cpp
@@ -1802,6 +1802,32 @@ ed::Node* ed::EditorContext::FindNodeAt(const ImVec2& p)
     return nullptr;
 }
 
+bool ed::EditorContext::IsNodeObscuredAt(Node* node, const ImVec2& p) const
+{
+    // m_Nodes is sorted by ascending Z (stable on creation order), so any node
+    // appearing after `node` in m_Nodes is drawn on top of it. Only scan that
+    // suffix to know whether `node` is visually covered at point p.
+    auto it = std::find_if(m_Nodes.begin(), m_Nodes.end(),
+        [node](const ObjectWrapper<Node>& w) { return w.m_Object == node; });
+    if (it == m_Nodes.end())
+        return false;
+    for (++it; it != m_Nodes.end(); ++it)
+    {
+        Node* other = it->m_Object;
+        if (other == node)
+            continue;
+        // Don't gate on m_IsLive: it is reset at frame start and only re-set
+        // inside each node's own BeginNode. This function may be called while
+        // building an earlier node, before later ones have been revived. Use
+        // the persistent last-frame geometry (m_Bounds) instead.
+        if (ImRect_IsEmpty(other->m_Bounds))
+            continue;
+        if (other->m_Bounds.Contains(p))
+            return true;
+    }
+    return false;
+}
+
 void ed::EditorContext::FindNodesInRect(const ImRect& r, vector<Node*>& result, bool append, bool includeIntersecting)
 {
     if (!append)
@@ -5150,7 +5176,9 @@ ed::Object* ed::DeleteItemsAction::DropCurrentItem()
 ed::NodeBuilder::NodeBuilder(EditorContext* editor):
     Editor(editor),
     m_CurrentNode(nullptr),
-    m_CurrentPin(nullptr)
+    m_CurrentPin(nullptr),
+    m_HoverSuppressionActive(false),
+    m_SavedHoveredId(0)
 {
 }
 
@@ -5240,10 +5268,34 @@ void ed::NodeBuilder::Begin(NodeId nodeId)
         ImGui::SetCursorPos(ImGui::GetCursorPos() + ImVec2(editorStyle.NodePadding.x, editorStyle.NodePadding.y));
         ImGui::BeginGroup();
     }
+
+    // If this node is currently covered by another node drawn on top of it
+    // under the cursor, prevent its widgets from claiming hover/active.
+    // ImGui uses "first hovered wins": without this, widgets in a back node
+    // submitted earlier in user code would steal hover from the visually
+    // front node. Set HoveredId to a sentinel so subsequent ItemHoverable()
+    // calls bail out; End() restores the previous value. ActiveId is left
+    // untouched so any in-progress interaction keeps working.
+    m_HoverSuppressionActive = false;
+    if (Editor->IsNodeObscuredAt(m_CurrentNode, ImGui::GetMousePos()))
+    {
+        ImGuiContext& g = *ImGui::GetCurrentContext();
+        m_SavedHoveredId = g.HoveredId;
+        g.HoveredId = ~static_cast<ImGuiID>(0); // sentinel, no real item will match
+        m_HoverSuppressionActive = true;
+    }
 }
 
 void ed::NodeBuilder::End()
 {
+    // Restore HoveredId before any further item submission.
+    if (m_HoverSuppressionActive)
+    {
+        ImGuiContext& g = *ImGui::GetCurrentContext();
+        g.HoveredId = m_SavedHoveredId;
+        m_HoverSuppressionActive = false;
+    }
+
     IM_ASSERT(nullptr != m_CurrentNode);
 
     if (auto drawList = Editor->GetDrawList())

--- a/imgui_node_editor_internal.h
+++ b/imgui_node_editor_internal.h
@@ -1192,6 +1192,11 @@ struct NodeBuilder
     ImDrawListSplitter m_Splitter;
     ImDrawListSplitter m_PinSplitter;
 
+    // Used by Begin/End to suppress hover claims from widgets in a node that
+    // is currently covered by another node under the cursor (see Begin()).
+    bool      m_HoverSuppressionActive;
+    ImGuiID   m_SavedHoveredId;
+
     NodeBuilder(EditorContext* editor);
     ~NodeBuilder();
 
@@ -1346,6 +1351,12 @@ struct EditorContext
     Node* FindNodeAt(const ImVec2& p);
     void FindNodesInRect(const ImRect& r, vector<Node*>& result, bool append = false, bool includeIntersecting = true);
     void FindLinksInRect(const ImRect& r, vector<Link*>& result, bool append = false);
+
+    // True if any node drawn on top of `node` contains `p`
+    // (`p` is in the same coordinate space as Node::m_Bounds).
+    // Drawing order follows m_Nodes after Z-sort, so we only need to scan
+    // the suffix that follows `node` in m_Nodes.
+    bool IsNodeObscuredAt(Node* node, const ImVec2& p) const;
 
     bool HasAnyLinks(NodeId nodeId) const;
     bool HasAnyLinks(PinId pinId) const;


### PR DESCRIPTION
Hi @thedmd,

Here is a proposed fix for a bug when nodes overlap: the back node might sometimes steal the focus (if its ui code comes first).

### Bug description

When two nodes overlap and both contain interactive widgets, the back node might react to hover instead of the front node.
This happens when the C++ rendering code for the back node is executed before the front node.

With the example below, AAA is executed before BBB

```cpp
ed::Begin("editor");

ed::BeginNode(ed::NodeId(1));
    if (ImGui::Button("AAA", ImVec2(300, 300)))  // wins clicks even when covered
        printf("AAA\n");
ed::EndNode();

ed::BeginNode(ed::NodeId(2));
    ImGui::Dummy(ImVec2(50, 50)); // empty header area
    if (ImGui::Button("BBB", ImVec2(300, 300)))
        printf("BBB\n");
ed::EndNode();

ed::End();
```

And AAA will "win" the click, even in the zone where AAA and BBB overlap below:

<img width="377" height="291" alt="image" src="https://github.com/user-attachments/assets/d067b9a9-b780-4ac2-8ed8-923f8c5738e5" />


### Analysis of the cause:

It seems like ImGui resolves overlapping items with "first hovered wins": the first `ItemHoverable()` call whose rect contains the cursor sets `g.HoveredId`, and later calls bail out. 

Items inside `BeginNode/EndNode` are submitted in user code order, regardless of node Z-order, so the node defined first
always wins. This conflicts with the editor's drawing order, which puts later-defined (or higher-Z) nodes on top.

Node-frame interaction in `BuildControl` already works correctly because it iterates `m_Nodes` in reverse and submits its own `InvisibleButton` per node: the front node's button is submitted first and wins.  But, the same guarantee does not extend to widgets the user submits between `BeginNode` and `EndNode`.



### Fix

1. In `NodeBuilder::Begin`, check whether any later-drawn node in the Z-sorted `m_Nodes` covers the cursor. If so, save `g.HoveredId` and set it to a sentinel value before user code runs, so any `ItemHoverable()` call inside this node's body bails out. 
2. `NodeBuilder::End` restores `g.HoveredId` first thing.

`g.ActiveId` is intentionally left alone so any interaction already in progress (e.g. a drag started before the front node moved on top) keeps working until mouse-up.

